### PR TITLE
chore: bump @antelopejs/interface-core to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "pnpm run build && ajs module test ."
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.2",
+    "@antelopejs/interface-core": "^0.0.3",
     "@antelopejs/interface-redis": "^0.0.2",
     "ioredis": "^5.10.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       '@antelopejs/interface-redis':
         specifier: ^0.0.2
         version: 0.0.2
@@ -50,6 +50,9 @@ packages:
 
   '@antelopejs/interface-core@0.0.2':
     resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@antelopejs/interface-redis@0.0.2':
     resolution: {integrity: sha512-BT4wtDG/xVqCrExcJUnMjBJRJdF2+t4GqkYB8r6vxU49hlZYW3cg8JBt7WL2n04ggBFi6znQg/B2YlVcZR+yuA==}
@@ -511,6 +514,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -1188,6 +1194,10 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
+  '@antelopejs/interface-core@0.0.3':
+    dependencies:
+      reflect-metadata: 0.2.2
+
   '@antelopejs/interface-redis@0.0.2':
     dependencies:
       '@antelopejs/interface-core': 0.0.2
@@ -1491,7 +1501,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       giget: 1.2.5
       jiti: 1.21.7
@@ -1633,6 +1643,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -1714,7 +1726,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Bump `@antelopejs/interface-core` dependency to `^0.0.3`

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `@antelopejs/interface-core` dependency from `^0.0.2` to `^0.0.3` and regenerates the lockfile accordingly. The lockfile also picks up a transitive `defu` upgrade (`6.1.4` → `6.1.7`) used by two snapshot entries. Note that `@antelopejs/interface-redis@0.0.2` still pins `@antelopejs/interface-core@0.0.2` in its own snapshot, so both versions of `interface-core` will be present in the install — this is normal pnpm behavior and should be harmless as long as the two versions are structurally compatible.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a dependency version bump with no logic changes.

Only two files changed: `package.json` and the regenerated lockfile. The bump is from a patch/minor pre-release version to the next, the lockfile looks internally consistent, and there are no logic or API changes in this repository.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps `@antelopejs/interface-core` specifier from `^0.0.2` to `^0.0.3`; no other changes. |
| pnpm-lock.yaml | Lockfile updated: resolves `@antelopejs/interface-core` to `0.0.3`, adds new `defu@6.1.7` entry, and bumps `defu` used by two transitive snapshot entries from `6.1.4` to `6.1.7`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[interface-redis-scheduler] -->|"bumped to 0.0.3"| B[interface-core v0.0.3]
    A -->|unchanged 0.0.2| C[interface-redis v0.0.2]
    C -->|pins snapshot| D[interface-core v0.0.2]
    B --> E[reflect-metadata v0.2.2]
    D --> E
    B -.->|transitive| F[defu v6.1.7]
    D -.->|transitive| G[defu v6.1.4]
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump @antelopejs/interface-core t..."](https://github.com/antelopejs/interface-redis-scheduler/commit/cd4a352de4172669bc20d0abf2dd76e55decb742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29167240)</sub>

<!-- /greptile_comment -->