### PR TITLE
chore(deps): interface deps as bounded peer + dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "test": "pnpm run build && ajs module test ."
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.3",
-    "@antelopejs/interface-redis": "^0.0.5",
     "ioredis": "^5.10.1"
   },
   "devDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-redis": ">=0.0.5 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
@@ -50,6 +50,10 @@
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-redis": ">=0.0.5 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "ioredis": "^5.10.1"
   },
   "devDependencies": {
-    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
-    "@antelopejs/interface-redis": ">=0.0.5 <1.0.0",
+    "@antelopejs/interface-core": "^0.0.5",
+    "@antelopejs/interface-redis": "^0.0.6",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,16 +8,16 @@ importers:
 
   .:
     dependencies:
-      '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
-      '@antelopejs/interface-redis':
-        specifier: ^0.0.5
-        version: 0.0.5
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
     devDependencies:
+      '@antelopejs/interface-core':
+        specifier: '>=0.0.3 <1.0.0'
+        version: 0.0.3
+      '@antelopejs/interface-redis':
+        specifier: '>=0.0.5 <1.0.0'
+        version: 0.0.5
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ importers:
         version: 5.10.1
     devDependencies:
       '@antelopejs/interface-core':
-        specifier: '>=0.0.3 <1.0.0'
-        version: 0.0.3
-      '@antelopejs/interface-redis':
-        specifier: '>=0.0.5 <1.0.0'
+        specifier: ^0.0.5
         version: 0.0.5
+      '@antelopejs/interface-redis':
+        specifier: ^0.0.6
+        version: 0.0.6(@antelopejs/interface-core@0.0.5)
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2
@@ -48,11 +48,13 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.3':
-    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+  '@antelopejs/interface-core@0.0.5':
+    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
 
-  '@antelopejs/interface-redis@0.0.5':
-    resolution: {integrity: sha512-rXaKg9M/cJ1iwcsdHfNHl1M7wc7lumEAoHLn5RbGZFLohrfl6a3WfPDWeQqfhOwm9jyOL04seDbYAYMH9weViA==}
+  '@antelopejs/interface-redis@0.0.6':
+    resolution: {integrity: sha512-c9at7pIFO2UbFlL4EFJht8Wt8uir33oj1Ja1rxMgPLPO8x8bOk4s9//Bqaigrjc0ELj/5zZQkqx3fHdmNru5QQ==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1187,13 +1189,13 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.3':
+  '@antelopejs/interface-core@0.0.5':
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-redis@0.0.5':
+  '@antelopejs/interface-redis@0.0.6(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-core': 0.0.5
       ioredis: 5.10.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Move interface deps to bounded peerDependencies + mirror in devDependencies.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reclassifies `@antelopejs/interface-core` and `@antelopejs/interface-redis` from `dependencies` to `peerDependencies` (with bounded `>=x.x.x <1.0.0` range) and mirrors them in `devDependencies` so the package builds and tests correctly in isolation. `ioredis` remains a direct `dependency` since it is not an interface-layer package.

- **`package.json`**: Both interface packages removed from `dependencies`, added to `peerDependencies` with `>=0.0.3 <1.0.0` / `>=0.0.5 <1.0.0` bounds, and duplicated into `devDependencies` for local development.
- **`pnpm-lock.yaml`**: Lock file updated to move both packages from the `dependencies` section to `devDependencies`; resolved versions remain `0.0.3` and `0.0.5` respectively.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change correctly externalises interface packages as peer dependencies without altering runtime behaviour for this package's own code.

The refactoring follows the standard peer-dependency pattern for interface/adapter packages. `ioredis` is correctly kept as a direct dependency, and the devDependencies mirror ensures local builds and tests continue to work. The bounded range `<1.0.0` is a reasonable guard for a pre-1.0 ecosystem.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Interface packages moved from dependencies to peerDependencies with bounded semver range and mirrored in devDependencies; ioredis correctly retained as a direct dependency. |
| pnpm-lock.yaml | Lock file reflects the move of both interface packages from dependencies to devDependencies; resolved versions are unchanged at 0.0.3 and 0.0.5. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Consumer["Consumer App"]
    Scheduler["@antelopejs/interface-redis-scheduler"]
    IRedis["@antelopejs/interface-redis\n>=0.0.5 <1.0.0"]
    ICore["@antelopejs/interface-core\n>=0.0.3 <1.0.0"]
    IORedis["ioredis\n^5.10.1"]

    Consumer -->|"installs (peerDep)"| IRedis
    Consumer -->|"installs (peerDep)"| ICore
    Consumer -->|"depends on"| Scheduler

    Scheduler -->|"peerDependency"| IRedis
    Scheduler -->|"peerDependency"| ICore
    Scheduler -->|"dependency"| IORedis

    subgraph DevOnly["devDependencies (local dev/test only)"]
        DevIRedis["@antelopejs/interface-redis 0.0.5"]
        DevICore["@antelopejs/interface-core 0.0.3"]
    end

    Scheduler -.->|"dev only"| DevIRedis
    Scheduler -.->|"dev only"| DevICore
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    Consumer["Consumer App"]
    Scheduler["@antelopejs/interface-redis-scheduler"]
    IRedis["@antelopejs/interface-redis\n>=0.0.5 <1.0.0"]
    ICore["@antelopejs/interface-core\n>=0.0.3 <1.0.0"]
    IORedis["ioredis\n^5.10.1"]

    Consumer -->|"installs (peerDep)"| IRedis
    Consumer -->|"installs (peerDep)"| ICore
    Consumer -->|"depends on"| Scheduler

    Scheduler -->|"peerDependency"| IRedis
    Scheduler -->|"peerDependency"| ICore
    Scheduler -->|"dependency"| IORedis

    subgraph DevOnly["devDependencies (local dev/test only)"]
        DevIRedis["@antelopejs/interface-redis 0.0.5"]
        DevICore["@antelopejs/interface-core 0.0.3"]
    end

    Scheduler -.->|"dev only"| DevIRedis
    Scheduler -.->|"dev only"| DevICore
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-redis-scheduler/commit/bd702ce62bc8ab87099d7a3f7f529cc8a482fddd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37739329)</sub>

<!-- /greptile_comment -->